### PR TITLE
updated documentation address

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -70,7 +70,7 @@
           <li><a href="#about">About</a></li>
           <li><a href="#pricing">Services</a></li>
           <!-- <li><a href="gateway.html">Gateway</a></li> -->
-          <li><a href="https://leto-1.gitbook.io/leto-documentation/">Documentation</a></li>
+          <li><a href="https://letodev.gitbook.io/leto-documentation-1/">Documentation</a></li>
 
 
 


### PR DESCRIPTION
"https://letodev.gitbook.io/leto-documentation-1/" is the new address